### PR TITLE
use DATA_LINK instead of READ_LINK to store microarray file link

### DIFF
--- a/genestack_client/data_importer.py
+++ b/genestack_client/data_importer.py
@@ -283,7 +283,7 @@ class DataImporter(object):
         method and metainfo.add_string(BioMetainfo.METHOD, method)
         if urls:
             for url in urls:
-                metainfo.add_external_link(BioMetainfo.READS_LINK, url)
+                metainfo.add_external_link(BioMetainfo.DATA_LINK, url)
         return self.__invoke_loader('genestack/experimentLoader', 'addMicroarrayAssay', parent, metainfo)
 
     def create_sequencing_assay(self, parent, name=None, urls=None,


### PR DESCRIPTION
With the current version, microarray files created with specifying the "urls" argument appear as Misconfigured!