### PR TITLE
Allow to specify host for genestack-user-setup init

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+* version 0.2.1
+  * allow to run genestack-user-setup init with -H/--host argument
+
 * version 0.2.0
   * compatibility fixes according to the upcoming changes in the genestack platform
     * new core returns JSON with application response stored in 'result' field

--- a/genestack-user-setup
+++ b/genestack-user-setup
@@ -294,7 +294,7 @@ class UserManagement(GenestackShell):
         config_path = config.get_settings_file()
         if not os.path.exists(config_path):
             print "No config file was found; starting init."
-            self.process_command(Init(), [], None)
+            self.process_command(Init(), ['--host', args.host], None)
         GenestackShell.set_shell_user(self, args)
 
 

--- a/genestack_client/genestack_shell.py
+++ b/genestack_client/genestack_shell.py
@@ -196,15 +196,16 @@ class GenestackShell(cmd.Cmd):
         cmd.Cmd.__init__(self, *args, **kwargs)
         self.connection = None
 
-    def get_shell_parser(self):
+    def get_shell_parser(self, offline=False):
         """
         Returns the parser for shell arguments.
 
         :return: parser for shell commands
         :rtype: argparse.ArgumentParser
         """
-        parser = ArgumentParser(conflict_handler='resolve', description=self.DESCRIPTION,
-                                parents=[make_connection_parser()])
+        parents = [] if offline else [make_connection_parser()]
+        parser = ArgumentParser(conflict_handler='resolve', description=self.DESCRIPTION, parents=parents)
+
         # override default help
         parser.add_argument('-h', '--help', action='store_true', help="show this help message and exit")
         parser.add_argument('command', metavar='<command>', help='"%s" or empty to use shell' % '", "'.join(self.COMMANDS), nargs='?')
@@ -242,6 +243,10 @@ class GenestackShell(cmd.Cmd):
                 connection = get_connection(args)
             else:
                 connection = None
+                # parse arguments that have same name as connection parser
+                parser = self.get_shell_parser(offline=True)
+                _, others = parser.parse_known_args()
+
             self.process_command(command, others, connection)
             exit(0)
 


### PR DESCRIPTION
Fix issues that `host`  argument was not provided to init command

- fix `genestack-user-setup -H server`:  If setup is not done Init command run automatically
- fix `genestack-user-setup init -H server` arguments that match connection arguments names were lost when running offline command