### PR TITLE
Dont show trace if it is not requested by user

### DIFF
--- a/genestack_client/genestack_connection.py
+++ b/genestack_client/genestack_connection.py
@@ -46,13 +46,14 @@ class Connection:
     To do so, you need to call the :py:meth:`~genestack_client.Connection.login` method.
     """
 
-    def __init__(self, server_url):
+    def __init__(self, server_url, debug=False):
         self.server_url = server_url
         cj = cookielib.CookieJar()
         self.__cookies_jar = cj
         self.opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cj), AuthenticationErrorHandler)
         self.opener.addheaders.append(('gs-extendSession', 'true'))
         self._no_redirect_opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cj), _NoRedirect, _NoRedirectError, AuthenticationErrorHandler)
+        self.debug = debug
 
     def __del__(self):
         try:
@@ -203,9 +204,12 @@ class Application:
         if isinstance(response, dict):
             error = response.get('error')
             if error is not None:
+                if self.connection.debug:
+                    stack_trace = response.get('errorStackTrace')
+                else:
+                    stack_trace = None
                 raise GenestackServerException(
-                    error, path, to_post,
-                    stack_trace=response.get('errorStackTrace')
+                    error, path, to_post, stack_trace=stack_trace
                 )
             return response.get('result', response)
         return response

--- a/genestack_client/settings/genestack_user.py
+++ b/genestack_client/settings/genestack_user.py
@@ -49,6 +49,10 @@ class User(object):
         self.email = email
         self.password = password  # TODO make property
         self.alias = alias or email
+        self.__debug = False
+
+    def set_debug(self):
+        self.__debug = True
 
     def get_connection(self, interactive=True):
         """
@@ -62,7 +66,7 @@ class User(object):
         :return: logged connection
         :rtype: ~genestack_client.Connection
         """
-        connection = Connection(_get_server_url(self.host))
+        connection = Connection(_get_server_url(self.host), debug=self.__debug)
         if self.email and self.password:
             connection.login(self.email, self.password)
         elif interactive:

--- a/genestack_client/settings/genestack_user.py
+++ b/genestack_client/settings/genestack_user.py
@@ -49,12 +49,8 @@ class User(object):
         self.email = email
         self.password = password  # TODO make property
         self.alias = alias or email
-        self.__debug = False
 
-    def set_debug(self):
-        self.__debug = True
-
-    def get_connection(self, interactive=True):
+    def get_connection(self, interactive=True, debug=False):
         """
         Return a logged-in connection for current user.
         If ``interactive`` is ``True`` and the password or email are unknown,
@@ -66,7 +62,7 @@ class User(object):
         :return: logged connection
         :rtype: ~genestack_client.Connection
         """
-        connection = Connection(_get_server_url(self.host), debug=self.__debug)
+        connection = Connection(_get_server_url(self.host), debug=debug)
         if self.email and self.password:
             connection.login(self.email, self.password)
         elif interactive:

--- a/genestack_client/utils.py
+++ b/genestack_client/utils.py
@@ -45,6 +45,7 @@ def make_connection_parser(user=None, password=None, host=None):
     group.add_argument('-H', '--host', default=host, help="server host", metavar='<host>')
     group.add_argument('-u', dest='user', metavar='<user>', default=user, help='user alias from settings or email')
     group.add_argument('-p', dest='pwd', default=password, metavar='<password>', help='user password')
+    group.add_argument('--debug', dest='debug', help='connect to server in debug mode', action='store_true')
     return parser
 
 
@@ -65,12 +66,17 @@ def get_user(args=None):
         args = make_connection_parser().parse_args()
 
     alias = args.user
+    user = None
     if not args.host and not args.pwd:
         if not alias and config.default_user:
-            return config.default_user
+            user = config.default_user
         if alias in config.users:
-            return config.users[alias]
-    return User(email=alias, host=args.host, password=args.pwd)
+            user = config.users[alias]
+    if user is None:
+        user = User(email=alias, host=args.host, password=args.pwd)
+    if args.debug:
+        user.set_debug()
+    return user
 
 
 def get_connection(args=None):

--- a/genestack_client/utils.py
+++ b/genestack_client/utils.py
@@ -66,17 +66,12 @@ def get_user(args=None):
         args = make_connection_parser().parse_args()
 
     alias = args.user
-    user = None
     if not args.host and not args.pwd:
         if not alias and config.default_user:
-            user = config.default_user
+            return config.default_user
         if alias in config.users:
-            user = config.users[alias]
-    if user is None:
-        user = User(email=alias, host=args.host, password=args.pwd)
-    if args.debug:
-        user.set_debug()
-    return user
+            return config.users[alias]
+    return User(email=alias, host=args.host, password=args.pwd)
 
 
 def get_connection(args=None):
@@ -90,4 +85,4 @@ def get_connection(args=None):
     :rtype: ~genestack_client.Connection
     """
     user = get_user(args)
-    return user.get_connection(interactive=True)
+    return user.get_connection(interactive=True, debug=args and args.debug)

--- a/genestack_client/utils.py
+++ b/genestack_client/utils.py
@@ -45,7 +45,7 @@ def make_connection_parser(user=None, password=None, host=None):
     group.add_argument('-H', '--host', default=host, help="server host", metavar='<host>')
     group.add_argument('-u', dest='user', metavar='<user>', default=user, help='user alias from settings or email')
     group.add_argument('-p', dest='pwd', default=password, metavar='<password>', help='user password')
-    group.add_argument('--debug', dest='debug', help='connect to server in debug mode', action='store_true')
+    group.add_argument('--debug', dest='debug', help='print additional stacktrace on error', action='store_true')
     return parser
 
 


### PR DESCRIPTION
This does not fix strange output of debug to console when using application manager (https://trac.genestack.com/ticket/5479) only hide it by default.