### PR TITLE
app-manager: wrap `sys.stdout` into Unicode-aware `StreamWriter`

### DIFF
--- a/genestack-application-manager
+++ b/genestack-application-manager
@@ -9,6 +9,8 @@
 # actual or intended publication of such source code.
 #
 
+import codecs
+import locale
 import sys
 import os
 import urllib2
@@ -20,6 +22,8 @@ from genestack_client import GenestackException
 from genestack_client.genestack_shell import GenestackShell, Command
 from genestack_client.utils import isatty
 
+# wrap sys.stdout into a StreamWriter to allow writing unicode.
+sys.stdout = codecs.getwriter(locale.getpreferredencoding())(sys.stdout)
 
 def validate_application_id(app_id):
     if len(app_id.split('/')) != 2:

--- a/genestack-application-manager
+++ b/genestack-application-manager
@@ -9,8 +9,6 @@
 # actual or intended publication of such source code.
 #
 
-import codecs
-import locale
 import sys
 import os
 import urllib2
@@ -22,8 +20,12 @@ from genestack_client import GenestackException
 from genestack_client.genestack_shell import GenestackShell, Command
 from genestack_client.utils import isatty
 
-# wrap sys.stdout into a StreamWriter to allow writing unicode.
-sys.stdout = codecs.getwriter(locale.getpreferredencoding())(sys.stdout)
+if sys.stdout.encoding is None:
+    # wrap sys.stdout into a StreamWriter to allow writing unicode to pipe
+    # (in that case Python 2 cannot determine encoding)
+    import codecs
+    import locale
+    sys.stdout = codecs.getwriter(locale.getpreferredencoding())(sys.stdout)
 
 def validate_application_id(app_id):
     if len(app_id.split('/')) != 2:


### PR DESCRIPTION
Otherwise Python can't guess encoding when piping out text and fails on, say,
non-ASCII versions.