### PR TITLE
Fix change password on windows

### DIFF
--- a/genestack_client/scripts/genestack_user_setup.py
+++ b/genestack_client/scripts/genestack_user_setup.py
@@ -146,7 +146,7 @@ class SetPassword(Command):
             user = select_user(users, None)  # TODO get current user for shell and command line
 
         while True:
-            user.password = getpass('Input password for %s: ' % user.alias)
+            user.password = getpass('Input password for %s: ' % user.alias.encode('utf-8'))
             try:
                 user.get_connection()
                 break


### PR DESCRIPTION
Windows `getpass` does not accept unicode