### PR TITLE
Add information about possible shell application commands for shell

### DIFF
--- a/genestack_client/genestack_shell.py
+++ b/genestack_client/genestack_shell.py
@@ -350,6 +350,18 @@ class GenestackShell(cmd.Cmd):
             print_exc()
         return 1
 
+    def get_commands_for_help(self):
+        """
+        Return list of command - description paires to shown in shell help command.
+
+        :return: command - description pairs
+        :rtype list[(str, str)]
+        """
+        commands = [('quit', 'Exit shell.')]
+        for name, value in self.COMMANDS.items():
+            commands.append((name, value().get_short_description()))
+        return sorted(commands)
+
     def do_help(self, line):
         print
 
@@ -359,15 +371,11 @@ class GenestackShell(cmd.Cmd):
             return
 
         if not line:
-            commands = {'quit': 'Exit shell.'}
-            for name, value in self.COMMANDS.items():
-                commands[name] = value().get_short_description()
             print self.doc_header
             print '=' * len(self.doc_header)
-            for command_name, short_description in sorted(commands.items()):
+            for command_name, short_description in self.get_commands_for_help():
                 print '%-20s%s' % (command_name, short_description)
             print '=' * len(self.doc_header)
-            return
 
         try:
             getattr(self, 'help_' + line)()

--- a/genestack_client/genestack_shell.py
+++ b/genestack_client/genestack_shell.py
@@ -373,8 +373,11 @@ class GenestackShell(cmd.Cmd):
         if not line:
             print self.doc_header
             print '=' * len(self.doc_header)
+            commands = self.get_commands_for_help()
+            max_size = max(len(command_name) for command_name, _ in commands)
+            help_size = max((20, max_size + 3))
             for command_name, short_description in self.get_commands_for_help():
-                print '%-20s%s' % (command_name, short_description)
+                print '%-*s%s' % (help_size, command_name, short_description)
             print '=' * len(self.doc_header)
 
         try:

--- a/genestack_client/scripts/shell.py
+++ b/genestack_client/scripts/shell.py
@@ -73,6 +73,16 @@ class Time(Call):
 class Shell(GenestackShell):
     COMMAND_LIST = [Time, Call]
 
+    def get_commands_for_help(self):
+        commands = GenestackShell.get_commands_for_help(self)
+        for data in self.connection.application(APPLICATION_SHELL).invoke('getCommands'):
+            commands.append((data['name'],
+                            'args: %s returns: %s. %s' % (
+                                                ', '.join(data['params']) or 'None',
+                                                data['returns'],
+                                                data['docs'] or 'No documentation')))
+        return commands
+
     def default(self, line):
         args = shlex.split(line)
         if args and args[0] in self.COMMANDS:


### PR DESCRIPTION
```
tester@genestack.com> help

Documented commands (type help <topic>):
========================================
call                        call another application's method
quit                        Exit shell.
time                        invoke with timer
groups                      args: None returns: java.util.List. No documentation
filter                      args: java.lang.String returns: java.util.List. No documentation
pwd                         args: None returns: java.lang.String. No documentation
tasks                       args: [Ljava.lang.String; returns: java.lang.Object. No documentation
activateUser                args: java.lang.String, boolean returns: java.lang.String. No documentation
confirm                     args: long, boolean returns: java.lang.String. No documentation
getFileStatus               args: java.lang.String returns: java.lang.String. No documentation
stderr                      args: int returns: java.lang.Object. No documentation
stderr                      args: int, int, int returns: java.lang.Object. No documentation
stdout                      args: int, int, int returns: java.lang.Object. No documentation
stdout                      args: int returns: java.lang.Object. No documentation
createGroup                 args: java.lang.String returns: java.lang.String. No documentation
ls                          args: java.lang.String, [Ljava.lang.String; returns: java.lang.Object. No documentation
unlink                      args: java.lang.String, java.lang.String returns: java.lang.Object. No documentation
applications                args: None returns: java.lang.Object. No documentation
dictionary                  args: java.lang.String, java.lang.String, [Ljava.lang.String; returns: java.util.List. No documentation
allFiles                    args: java.lang.String returns: java.util.List. No documentation
allFiles                    args: None returns: java.util.List. No documentation
ln                          args: java.lang.String, java.lang.String returns: java.lang.Object. No documentation
ln                          args: java.lang.String, java.lang.String, java.lang.String returns: java.lang.Object. No documentation
serializeFilter             args: java.lang.String returns: com.genestack.api.files.filters.FileFilter. No documentation
applyFilter                 args: com.genestack.api.files.filters.FileFilter returns: java.util.List. No documentation
locks_test                  args: int, int returns: java.lang.String. No documentation
invite                      args: java.lang.String, java.util.List returns: void. No documentation
invite                      args: java.lang.String, java.util.List, java.lang.String returns: java.lang.String. No documentation
listSent                    args: java.lang.String returns: java.lang.Object. No documentation
listSent                    args: None returns: java.lang.Object. No documentation
listReceived                args: None returns: java.lang.Object. No documentation
permissionsTestWithWarmUp   args: None returns: java.lang.String. No documentation
permissionsTest             args: None returns: java.lang.String. No documentation
referenceGenomeTest         args: None returns: java.lang.String. No documentation
dictionaryAutocomplete      args: java.lang.String, java.lang.String returns: java.util.List. No documentation
dictionaryParents           args: java.lang.String, java.lang.String, java.lang.String returns: java.util.List. No documentation
dictionaryChildren          args: java.lang.String, java.lang.String, java.lang.String returns: java.util.List. No documentation
getCommands                 args: None returns: java.util.List. No documentation
========================================
```