### PR TITLE
Encode exception message

### DIFF
--- a/genestack_client/genestack_exceptions.py
+++ b/genestack_client/genestack_exceptions.py
@@ -26,11 +26,7 @@ class GenestackServerException(GenestackException):
         :param stack_trace: server stack trace
         :type stack_trace: str
         """
-        def to_str(val):
-            if isinstance(val, unicode):
-                return val.encode('utf-8', 'ignore')
-            return val
-        message = to_str(message)
+        message = message.encode('utf-8', 'ignore') if isinstance(message, unicode) else message
 
         GenestackException.__init__(self, message, path, post_data, debug, stack_trace)
         self.message = message

--- a/genestack_client/genestack_exceptions.py
+++ b/genestack_client/genestack_exceptions.py
@@ -26,6 +26,12 @@ class GenestackServerException(GenestackException):
         :param stack_trace: server stack trace
         :type stack_trace: str
         """
+        def to_str(val):
+            if isinstance(val, unicode):
+                return val.encode('utf-8', 'ignore')
+            return val
+        message = to_str(message)
+
         GenestackException.__init__(self, message, path, post_data, debug, stack_trace)
         self.message = message
         self.debug = debug


### PR DESCRIPTION
Fix crash on exception print.

Steps to reproduce:
  - start genestack-shell
  - type `ы` 

