### PR TITLE
Handle more connection exceptions.

### DIFF
--- a/genestack_client/chunked_upload.py
+++ b/genestack_client/chunked_upload.py
@@ -7,6 +7,10 @@ import re
 from datetime import datetime
 from io import BytesIO
 from threading import Thread, Lock, Condition
+
+import sys
+
+from OpenSSL.SSL import SysCallError
 from requests.exceptions import RequestException
 
 from genestack_client.utils import isatty
@@ -37,7 +41,7 @@ class Chunk(object):
         self.size = size
 
     def __str__(self):
-        return "Chunk %s %s for %s" % (self.data['resumableChunkNumber'], self.size, self.data['resumableRelativePath'])
+        return "Chunk %s %s bytes for %s" % (self.data['resumableChunkNumber'], self.size, self.data['resumableRelativePath'])
 
     def get_file(self):
         container = BytesIO()
@@ -215,10 +219,12 @@ class ChunkedUpload(object):
                                                           data=chunk.data,
                                                           files={'file': file_cache},
                                                           follow=False)
-            except RequestException as e:
+            except (RequestException, SysCallError) as e:
                 # check that any type of connection error occurred and retry.
                 time.sleep(RETRY_INTERVAL)
                 error = str(e)
+                if self.connection.debug:
+                    sys.stderr.write('%s/%s attempt to upload %s failed. Connection error: %s\n' % (attempt + 1, RETRY_ATTEMPTS, chunk, error))
                 continue
             # done without errors
             if response.status_code == 200:


### PR DESCRIPTION
If connection is not stable different connection errors occurred. 
 - added more exceptions to try-except statement.
 - added `--debug` to connection will print more info, not very useful, but will indicate progress. Since whole cycle of 5 fail attempts takes couple of minutes.



SSL_ERROR_SYSCALL

Some I/O error occurred. The OpenSSL error queue may contain more information on the error. If the error queue is empty (i.e. ERR_get_error() returns 0), ret can be used to find out more about the error: If ret == 0, an EOF was observed that violates the protocol. If ret == -1, the underlying BIO reported an I/O error (for socket I/O on Unix systems, consult errno for details).
