### PR TITLE
Add check if no files was found. Fixes #7332

### DIFF
--- a/genestack_client/scripts/genestack_application_manager.py
+++ b/genestack_client/scripts/genestack_application_manager.py
@@ -407,7 +407,8 @@ def resolve_jar_file(file_path):
         raise GenestackException('More than one JAR file was found inside %s:\n'
                                  ' %s' % (file_path, '\n '.join(jar_files)))
     elif not jar_files:
-        raise GenestackException('No JAR file was found inside: "%s"' % file_path)
+        raise GenestackException('No JAR files were found within given files/directories: "%s"' %
+                                 file_path)
 
     return jar_files[0]
 

--- a/genestack_client/scripts/genestack_application_manager.py
+++ b/genestack_client/scripts/genestack_application_manager.py
@@ -117,6 +117,8 @@ class Install(Command):
 
     def run(self):
         jar_files = [resolve_jar_file(f) for f in match_jar_globs(self.args.files)]
+        if not jar_files:
+            raise GenestackException('No JAR file was found')
         upload_file(
             self.connection.application(APPLICATION_ID),
             jar_files, self.args.version, self.args.override,
@@ -405,7 +407,7 @@ def resolve_jar_file(file_path):
         raise GenestackException('More than one JAR file was found inside %s:\n'
                                  ' %s' % (file_path, '\n '.join(jar_files)))
     elif not jar_files:
-        raise GenestackException('No JAR file was found inside %s' % file_path)
+        raise GenestackException('No JAR file was found inside: "%s"' % file_path)
 
     return jar_files[0]
 


### PR DESCRIPTION
`match_jar_globs` will return empty list if folder is not found