### PR TITLE
shell: Adjust help width to terminal width

### DIFF
--- a/genestack_client/genestack_shell.py
+++ b/genestack_client/genestack_shell.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from argparse import ArgumentParser
+from argparse import ArgumentParser, HelpFormatter
 import sys
 import os
 import cmd
@@ -10,8 +10,7 @@ from traceback import print_exc
 from genestack_client import (GenestackVersionException, GenestackAuthenticationException, GenestackException)
 from version import __version__
 
-from utils import isatty, make_connection_parser, get_connection
-
+from utils import isatty, make_connection_parser, get_connection, get_terminal_width
 
 if isatty():
     # To have autocomplete and console navigation on windows you need to have pyreadline installed.
@@ -36,7 +35,8 @@ def get_help(parser):
     # Code almost identical with parser.print_help() with next changes:
     # it return text instead print
     # it place group 'command arguments' to the first place
-    formatter = parser._get_formatter()
+    width = min(get_terminal_width(), 100)
+    formatter = HelpFormatter(prog=parser.prog, max_help_position=30, width=width)
     # usage
     formatter.add_usage(parser.usage, parser._actions,
                         parser._mutually_exclusive_groups)

--- a/genestack_client/utils.py
+++ b/genestack_client/utils.py
@@ -9,7 +9,7 @@ from genestack_client import GenestackException
 
 def get_terminal_width():
     """
-    Return terminal width.
+    Return terminal width in characters (defaults to 80).
 
     :return: terminal width
     :rtype: int

--- a/genestack_client/utils.py
+++ b/genestack_client/utils.py
@@ -1,9 +1,25 @@
 # -*- coding: utf-8 -*-
 
 import argparse
+import subprocess
 import sys
 
 from genestack_client import GenestackException
+
+
+def get_terminal_width():
+    """
+    Return terminal width.
+
+    :return: terminal width
+    :rtype: int
+    """
+    try:
+        rows, columns = subprocess.check_output(['stty', 'size']).decode().split()
+        return int(columns)
+    except Exception as e:
+        sys.stderr.write('Fail to get terminal size, use 80 as default: %s' % e)
+        return 80
 
 
 def isatty():


### PR DESCRIPTION
I choose 100 as upper bound for help width, because its looks better for me than 120.