### PR TITLE
Fix of an extra deprecated paramater warning

### DIFF
--- a/genestack_client/files_util.py
+++ b/genestack_client/files_util.py
@@ -370,7 +370,8 @@ class FilesUtil(Application):
         :type: str
         :rtype: None
         """
-        sys.stderr.write('Parameter `password` is deprecated. Use `share_files` without password.\n')
+        if password is not None:
+            sys.stderr.write('Parameter `password` is deprecated. Use `share_files` without password.\n')
         share_utils = self.connection.application('genestack/shareutils')
 
         accessions = list(accessions) if isinstance(accessions, (list, tuple, set)) else [accessions]
@@ -398,7 +399,8 @@ class FilesUtil(Application):
         :type: str
         :rtype: None
         """
-        sys.stderr.write('Parameter `password` is deprecated. Use `share_folder` without password.\n')
+        if password is not None:
+            sys.stderr.write('Parameter `password` is deprecated. Use `share_folder` without password.\n')
         self.share_files([folder_accession], group, destination_folder=destination_folder)
         share_utils = self.connection.application('genestack/shareutils')
         limit = 100

--- a/genestack_client/sudo_utils.py
+++ b/genestack_client/sudo_utils.py
@@ -15,8 +15,7 @@ class SudoUtils(Application):
 
     def is_sudo_active(self):
         """
-        Returns a boolean indicating whether superuser mode is still active. This request extends
-        the duration of a superuser session.
+        Returns a boolean indicating whether superuser mode is still active.
 
         :return: ``True`` if sudo is active
         :rtype: bool


### PR DESCRIPTION
Warning about deprecated usage of `password` in `share_folder` and `share_files` should be logged only if `password` is not None