### PR TITLE
setup: refuse to install for Python != 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     long_description=long_descrption,
     long_description_content_type="text/markdown",
     install_requires=['keyring', 'requests', 'pyOpenSSL'],
+    python_requires='>=2.7,<3',
     entry_points={
         'console_scripts': [
             'genestack-user-setup = genestack_client.scripts.genestack_user_setup:main',


### PR DESCRIPTION
As of now, one could mistakenly install Python Client for Python 3, just to break everything.  It should be forbidden, like this:
```
 % pip install .
Processing /Users/skrattaren/genestack/python-client
genestack-client requires Python '>=2.7,<3' but the running Python is 3.6.5
```