### PR TITLE
metainfo: implement `__repr__()` for all `MetainfoScalarValue`s

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 * 0.25.0
     * Fixed `Metainfo.parse_metainfo_from_dict(m)` modifies `m` https://github.com/genestack/python-client/issues/269
     * Added 'FilesUtil.get_metainfo_values_as_string_list' method
+    * Implement simple `MetainfoScalarValue.__repr__()` for its subclasses
 
 * 0.24.0
     * Added `ShareUtil` class for working with sharing-related operations

--- a/genestack_client/metainfo_scalar_values.py
+++ b/genestack_client/metainfo_scalar_values.py
@@ -54,12 +54,18 @@ class BooleanValue(MetainfoScalarValue):
     def get_boolean(self):
         return bool(self.get('value'))
 
+    def __repr__(self):
+        return '{}({})'.format(self.__class__.__name__, self.get_boolean())
+
 
 class IntegerValue(MetainfoScalarValue):
     _TYPE = 'integer'
 
     def get_int(self):
         return int(self.get('value'))
+
+    def __repr__(self):
+        return '{}({})'.format(self.__class__.__name__, self.get_int())
 
 
 class MemorySizeValue(MetainfoScalarValue):
@@ -68,12 +74,18 @@ class MemorySizeValue(MetainfoScalarValue):
     def get_int(self):
         return int(self.get('value'))
 
+    def __repr__(self):
+        return '{}({})'.format(self.__class__.__name__, self.get_int())
+
 
 class DecimalValue(MetainfoScalarValue):
     _TYPE = 'decimal'
 
     def get_decimal(self):
         return float(self.get('value'))
+
+    def __repr__(self):
+        return '{}({})'.format(self.__class__.__name__, self.get_decimal())
 
 
 class ExternalLink(MetainfoScalarValue):

--- a/genestack_client/metainfo_scalar_values.py
+++ b/genestack_client/metainfo_scalar_values.py
@@ -24,6 +24,9 @@ class MetainfoScalarValue(dict):
         super(MetainfoScalarValue, self).__init__()
         self._set_fields(value)
 
+    def __repr__(self):
+        return '{}({})'.format(self.__class__.__name__, self.get('value'))
+
     @staticmethod
     def _xstr(arg):
         """
@@ -81,6 +84,9 @@ class ExternalLink(MetainfoScalarValue):
             text = os.path.basename(urlparse(unquote(url)).path)
         self._set_fields({'text': text, 'url': url, 'format': fmt})
 
+    def __repr__(self):
+        return '{}({})'.format(self.__class__.__name__, self.get_url())
+
     def get_text(self):
         return self.get('text')
 
@@ -98,6 +104,9 @@ class FileReference(MetainfoScalarValue):
         super(MetainfoScalarValue, self).__init__()
         self._set_fields({'accession': accession})
 
+    def __repr__(self):
+        return '{}({})'.format(self.__class__.__name__, self.get_accession())
+
     def get_accession(self):
         return self.get('accession')
 
@@ -112,6 +121,9 @@ class DateTimeValue(MetainfoScalarValue):
         super(MetainfoScalarValue, self).__init__()
         milliseconds = self._parse_date_time(time)
         self._set_fields({'date': milliseconds})
+
+    def __repr__(self):
+        return '{}({})'.format(self.__class__.__name__, self.get_date())
 
     @staticmethod
     def _can_be_cast_to_int(time_str):
@@ -162,6 +174,9 @@ class Person(MetainfoScalarValue):
         super(MetainfoScalarValue, self).__init__()
         self._set_fields({'name': name, 'phone': phone, 'email': email})
 
+    def __repr__(self):
+        return '{}({})'.format(self.__class__.__name__, self.get_person())
+
     def get_person(self):
         return {key: self.get(key) for key in {'name', 'phone', 'email'}}
 
@@ -180,6 +195,9 @@ class Publication(MetainfoScalarValue):
             'issueNumber': issue_number,
             'pages': pages
         })
+
+    def __repr__(self):
+        return '{}({})'.format(self.__class__.__name__, self.get_publication())
 
     def get_publication(self):
         return {key: self.get(key) for key in {'identifiers', 'journalName', 'issueDate', 'title', 'authors',
@@ -204,6 +222,9 @@ class Organization(MetainfoScalarValue):
             'email': email,
             'url': url
         })
+
+    def __repr__(self):
+        return '{}({})'.format(self.__class__.__name__, self.get_organization())
 
     def get_organization(self):
         return {key: self.get(key) for key in {'name', 'department', 'country', 'city', 'street',

--- a/genestack_client/metainfo_scalar_values.py
+++ b/genestack_client/metainfo_scalar_values.py
@@ -26,7 +26,7 @@ class MetainfoScalarValue(dict):
         self._set_fields(value)
 
     def __repr__(self):
-        return '{}({})'.format(self.__class__.__name__, self.get('value'))
+        return '{}({!r})'.format(self.__class__.__name__, self.get('value'))
 
     @staticmethod
     def _xstr(arg):

--- a/genestack_client/metainfo_scalar_values.py
+++ b/genestack_client/metainfo_scalar_values.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+from pprint import pformat
 from urlparse import unquote, urlparse
 
 from genestack_client import GenestackException
@@ -175,7 +176,8 @@ class Person(MetainfoScalarValue):
         self._set_fields({'name': name, 'phone': phone, 'email': email})
 
     def __repr__(self):
-        return '{}({})'.format(self.__class__.__name__, self.get_person())
+        return '{}({})'.format(self.__class__.__name__,
+                               pformat(self.get_person()))
 
     def get_person(self):
         return {key: self.get(key) for key in {'name', 'phone', 'email'}}
@@ -197,7 +199,8 @@ class Publication(MetainfoScalarValue):
         })
 
     def __repr__(self):
-        return '{}({})'.format(self.__class__.__name__, self.get_publication())
+        return '{}({})'.format(self.__class__.__name__,
+                               pformat(self.get_publication()))
 
     def get_publication(self):
         return {key: self.get(key) for key in {'identifiers', 'journalName', 'issueDate', 'title', 'authors',
@@ -224,7 +227,8 @@ class Organization(MetainfoScalarValue):
         })
 
     def __repr__(self):
-        return '{}({})'.format(self.__class__.__name__, self.get_organization())
+        return '{}({})'.format(self.__class__.__name__,
+                               pformat(self.get_organization()))
 
     def get_organization(self):
         return {key: self.get(key) for key in {'name', 'department', 'country', 'city', 'street',


### PR DESCRIPTION
Simple `__repr__` implementations for metainfo values.
```py
mi = genestack_client.Metainfo()
KEY = 'gs:test'
mi.add_integer(KEY, 1)
print(mi.get(KEY))
```
Before:
```
[{'type': 'integer', 'value': '1'}]
```
After:
```
[IntegerValue(1)]
```
References #274.