### PR TITLE
Fix date metainfo failure in non-UTC timezones

### DIFF
--- a/test/test_metainfo.py
+++ b/test/test_metainfo.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python2.7
 # -*- coding: utf-8 -*-
 
+import datetime
 import os
 import sys
+import time
 
 import pytest
 
@@ -20,6 +22,16 @@ def conn():
     conn = get_connection(make_connection_parser().parse_args())
     return conn
 
+
+def _strptime_local(date, fmt_str):
+    '''
+    Helper function to wrap `strptime` returning local (TZ-aware) datetime
+    '''
+    tzless_dt = datetime.datetime.strptime(date, fmt_str)
+    ts_now = time.time()
+    tz_offset = (datetime.datetime.fromtimestamp(ts_now)
+                 - datetime.datetime.utcfromtimestamp(ts_now))
+    return tzless_dt + tz_offset
 
 def test_metainfo_io(conn):
     data_importer = DataImporter(conn)
@@ -44,7 +56,7 @@ def test_metainfo_io(conn):
         metainfo = fu.collect_metainfos([report_file])[0]
         assert metainfo.get('a')[0].get_boolean()
         assert isinstance(metainfo.get('b')[0].get_accession(), str)
-        assert metainfo.get('c')[0].get_date() == datetime.datetime.strptime('2015-12-13', '%Y-%m-%d')
+        assert metainfo.get('c')[0].get_date() == _strptime_local('2015-12-13', '%Y-%m-%d')
         assert metainfo.get('d')[0].get_int() == 239
         assert metainfo.get('e')[0].get_decimal() == 238.583
         assert metainfo.get('e')[1].get_decimal() == -13.4


### PR DESCRIPTION
`datetime.fromtimestamp()` returns local datetime for timestamp stored in `DateTimeValue`, while in tests we create and compare it with UTC datetime.

-------
I don't think it's the best solution, but this does fix tests, ad I would like to use it as a starting point for the discussion on how do we use and want to use datetime objects here, because it looks like a mess to me.