### PR TITLE
Improve handling of result of `FilesUtil.collect_metainfos()` in tests

### DIFF
--- a/test/test_metainfo.py
+++ b/test/test_metainfo.py
@@ -41,7 +41,7 @@ def test_metainfo_io(conn):
     report_file = None
     try:
         report_file = data_importer.create_report_file(metainfo=info, urls=[TEST_URL], parent=created)
-        metainfo = fu.collect_metainfos([report_file])[0]
+        metainfo = next(iter(fu.collect_metainfos([report_file])))
         assert metainfo.get('a')[0].get_boolean()
         assert isinstance(metainfo.get('b')[0].get_accession(), str)
         assert metainfo.get('c')[0].get_date() == datetime.datetime.strptime('2015-12-13', '%Y-%m-%d')


### PR DESCRIPTION
`collect_metainfos` returns `map` result which is list in Python 2, but an iterator in Python 3. 
`next(iter())` (instead of `[0]`) works fine in both versions.