### PR TITLE
[JBKB-996] Delete findMetainfoRelatedTerms method from Genestack Core

### DIFF
--- a/genestack_client/__init__.py
+++ b/genestack_client/__init__.py
@@ -27,7 +27,7 @@ from genome_query import GenomeQuery
 from utils import get_connection, get_user, make_connection_parser, validate_constant
 from file_filters import *
 from share_util import ShareUtil
-from files_util import FilesUtil, MatchType, SortOrder, SpecialFolders
+from files_util import FilesUtil, SortOrder, SpecialFolders
 from datasets_util import DatasetsUtil
 from groups_util import GroupsUtil
 from organization_util import OrganizationUtil


### PR DESCRIPTION
findMetainfoRelatedTerms is deleted. MatchType class is deleted too.