### PR TITLE
ODM-10841: simplify logic to determine odm host

### DIFF
--- a/genestack_client/settings/genestack_user.py
+++ b/genestack_client/settings/genestack_user.py
@@ -1,11 +1,5 @@
 # -*- coding: utf-8 -*-
 
-#  Copyright (c) 2011-2023 Genestack Limited
-#  All Rights Reserved
-#  THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF GENESTACK LIMITED
-#  The copyright notice above does not evidence any
-#  actual or intended publication of such source code.
-
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division


### PR DESCRIPTION
- localhost check was removed because it's not needed anymore
- use /health endpoint to check server status
- remove cycle to resolve host name, checking just `%s/frontend/health` should be enough