### PR TITLE
ODM-5452: do not initialise gene dictionaries

### DIFF
--- a/odm_sdk/scripts/internal/upload_dictionaries_with_specific_metainfo.py
+++ b/odm_sdk/scripts/internal/upload_dictionaries_with_specific_metainfo.py
@@ -80,7 +80,6 @@ def upload_gene_dictionaries():
         dictionary_accessions.append(gene_ontology_accession)
 
     sharing(connection, dictionary_accessions)
-    initialization(connection, dictionary_accessions)
 
 
 def main():


### PR DESCRIPTION
Do not initialise gene dictionaries by default (as it was before) to keep gene variant search result as they were before.