### PR TITLE
[ODM-11738] Transfer wipeStudy to MetainfoEditorLibrary

### DIFF
--- a/odm_sdk/scripts/delete_study_or_template.py
+++ b/odm_sdk/scripts/delete_study_or_template.py
@@ -24,7 +24,7 @@ def main():
 
     accession = args.accession
     try:
-        connection.application('genestack/arvados-importer').invoke('wipeStudy', accession)
+        connection.application('genestack/study-metainfo-editor').invoke('wipeStudy', accession)
         print(colored("Success", GREEN))
     except GenestackServerException as e:
         p = re.compile('File .* not found')


### PR DESCRIPTION
[ODM-11738] Transfer wipeStudy to MetainfoEditorLibrary

- replaced usage of `arvados-importer` application with `study-metainfo-editor`

Linked PRs:
- https://github.com/genestack/ui/pull/83
- https://github.com/genestack/unified/pull/3345
- https://github.com/genestack/user-guide/pull/249
- https://github.com/genestack/functional-tests/pull/562

[ODM-11738]: https://genestack.atlassian.net/browse/ODM-11738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ